### PR TITLE
Test Progress + FK Update

### DIFF
--- a/sync/index.js
+++ b/sync/index.js
@@ -1,7 +1,13 @@
 const { createHash } = await import("node:crypto");
 import mysql from "mysql2/promise";
 
-import { outputFormattedLog, getCommandLineInput, printErrorMessage, printInfoMessage } from "dx-cli-tools/helpers.js";
+import {
+    outputFormattedLog,
+    getCommandLineInput,
+    printErrorMessage,
+    printInfoMessage,
+    printSubHeadingMessage,
+} from "dx-cli-tools/helpers.js";
 import {
     DB_IMPLEMENTATION_TYPES,
     HEADING_FORMAT,
@@ -386,7 +392,7 @@ const createTables = async (tablesToCreate = []) => {
         try {
             await connection.query(createTableSql);
         } catch (err) {
-            rollbackConnsAndExitProcess(`Could not create table '${tableName}': ${err?.sqlMessage}`, err);
+            await rollbackConnsAndExitProcess(`Could not create table '${tableName}': ${err?.sqlMessage}`, err);
         }
     }
 
@@ -403,7 +409,6 @@ const updateTables = async () => {
         if (!queryStringsByModule[moduleName]) queryStringsByModule[moduleName] = [];
         const [tableColumns] = await connection.query(`SHOW FULL COLUMNS FROM ${entityName}`);
         let tableColumnsNormalized = {};
-
         const entityAttributeDefinitions = dataModel[entityName]["attributes"];
         const expectedColumns = getEntityExpectedColumns(entityName);
 
@@ -470,12 +475,26 @@ const updateTables = async () => {
                     break;
                 }
 
-                const dataModelOption =
+                let dataModelOption =
                     columnOption === "lengthOrValues" && entityAttributeDefinitions[columnName][columnOption] !== null
                         ? entityAttributeDefinitions[columnName][columnOption].toString()
                         : entityAttributeDefinitions[columnName][columnOption];
 
-                if (dataModelOption !== tableColumnsNormalized[tableColumn["Field"]][columnOption]) {
+                if (
+                    columnOption === "type" &&
+                    typeof dataModelOption === "string" &&
+                    dataModelOption.toLowerCase() === "boolean"
+                ) {
+                    dataModelOption = "tinyint";
+                } else if (
+                    dataModelOption === null &&
+                    columnOption === "lengthOrValues" &&
+                    tableColumnsNormalized[tableColumn["Field"]].type === "tinyint"
+                ) {
+                    dataModelOption = "1";
+                }
+
+                if (dataModelOption != tableColumnsNormalized[tableColumn["Field"]][columnOption]) {
                     queryStringsByModule[moduleName].push(
                         `ALTER TABLE ${entityName} ${getAlterColumnSql(
                             columnName,
@@ -542,7 +561,7 @@ const updateTables = async () => {
             try {
                 await connection.query(query);
             } catch (err) {
-                rollbackConnsAndExitProcess(`Could not execute query: ${err?.sqlMessage}`, err);
+                await rollbackConnsAndExitProcess(`Could not execute query: ${err?.sqlMessage}`, err);
             }
         }
     }
@@ -564,17 +583,22 @@ const updateIndexes = async () => {
         const moduleName = dataModel[entityName].module;
         const { connection } = moduleConnections[moduleName];
 
-        const [indexCheckResults] = await connection.query(`SHOW INDEX FROM ${entityName}`);
+        const [existingIndexDataArray] =
+            await connection.query(`SELECT S.TABLE_NAME, S.INDEX_NAME, S.COLUMN_NAME, S.NULLABLE, S.INDEX_TYPE, RC.REFERENCED_TABLE_NAME
+                        FROM INFORMATION_SCHEMA.STATISTICS S LEFT JOIN 
+                        INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS RC
+                        ON RC.CONSTRAINT_NAME = S.INDEX_NAME
+                        WHERE S.TABLE_NAME = '${entityName}';`);
         let existingIndexes = [];
-        for (const index of indexCheckResults) {
-            existingIndexes.push(index["Key_name"]);
+        for (const index of existingIndexDataArray) {
+            existingIndexes.push(index["INDEX_NAME"]);
         }
 
         const entityRelationshipConstraints = getEntityRelationshipConstraint(entityName);
-        const expectedIndexes = entityRelationshipConstraints.map((obj) => obj.constraintName);
-        for (const indexObj of dataModel[entityName]["indexes"]) {
-            const indexName = indexObj["indexName"];
-            expectedIndexes.push(indexName);
+        const expectedIndexNames = entityRelationshipConstraints.map((obj) => obj.constraintName);
+        for (const indexObj of dataModel[entityName].indexes) {
+            const indexName = indexObj.indexName;
+            expectedIndexNames.push(indexName);
 
             if (!existingIndexes.includes(indexName)) {
                 // Let's add this index
@@ -595,7 +619,7 @@ const updateIndexes = async () => {
                         addIndexSqlString = `ALTER TABLE ${entityName} ADD FULLTEXT ${indexName} (${keyColumn})`;
                         break;
                     default:
-                        rollbackConnsAndExitProcess(
+                        await rollbackConnsAndExitProcess(
                             `Invalid index choice specified for '${indexObj["indexName"]}' on '${entityName}'.
                             Provided: '${indexObj["indexChoice"]}'.
                             Valid options: index|unique|fulltext|spatial`,
@@ -605,7 +629,7 @@ const updateIndexes = async () => {
                 try {
                     await connection.query(addIndexSqlString);
                 } catch (err) {
-                    rollbackConnsAndExitProcess(
+                    await rollbackConnsAndExitProcess(
                         `Could not add ${indexObj[
                             "indexChoice"
                         ].toUpperCase()} '${indexName}' to table '${entityName}': 
@@ -618,16 +642,21 @@ const updateIndexes = async () => {
             }
         }
 
-        for (const existingIndex of existingIndexes) {
+        for (const { INDEX_NAME: existingIndex, REFERENCED_TABLE_NAME } of existingIndexDataArray) {
             if (existingIndex.toLowerCase() === "primary") {
                 continue;
             }
 
-            if (!expectedIndexes.includes(existingIndex)) {
+            if (REFERENCED_TABLE_NAME) {
+                // FK Index - handled elsewhere - do NOT drop
+                continue;
+            }
+
+            if (!expectedIndexNames.includes(existingIndex)) {
                 try {
                     await connection.query(`ALTER TABLE ${entityName} DROP INDEX \`${existingIndex}\`;`);
                 } catch (err) {
-                    rollbackConnsAndExitProcess(
+                    await rollbackConnsAndExitProcess(
                         `Could not drop INDEX ${existingIndex} to table ${entityName}: ${err?.sqlMessage ?? ""}`,
                         err,
                     );
@@ -655,18 +684,22 @@ const updateRelationships = async (dropOnly = false) => {
     }
 
     let updatedRelationships = { added: 0, removed: 0 };
+    let existingForeignKeyDataArray = [];
+
     for (const [entityName, { module: moduleName }] of Object.entries(dataModel)) {
         const { connection, schemaName } = moduleConnections[moduleName];
         const entityRelationshipConstraints = getEntityRelationshipConstraint(entityName);
         try {
-            const [results] = await connection.query(`SELECT * FROM information_schema.REFERENTIAL_CONSTRAINTS 
-                WHERE TABLE_NAME = '${entityName}' AND CONSTRAINT_SCHEMA = '${schemaName}';`);
-
+            const [results] = await connection.query(`SELECT KCU.* FROM
+                INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS RC INNER JOIN
+                INFORMATION_SCHEMA.KEY_COLUMN_USAGE KCU ON RC.CONSTRAINT_NAME = KCU.CONSTRAINT_NAME
+                WHERE KCU.TABLE_NAME = '${entityName}';`);
             for (const foreignKeyResult of results) {
                 let foundConstraint = null;
+                const resultUniqueCombination = `${foreignKeyResult.TABLE_NAME}_${foreignKeyResult.REFERENCED_TABLE_NAME}_${foreignKeyResult.COLUMN_NAME}`;
                 if (entityRelationshipConstraints.length) {
                     foundConstraint = entityRelationshipConstraints.find(
-                        (obj) => obj.constraintName === foreignKeyResult.CONSTRAINT_NAME,
+                        (obj) => obj.dataModelUniqueCombination === resultUniqueCombination,
                     );
                 }
 
@@ -675,7 +708,7 @@ const updateRelationships = async (dropOnly = false) => {
                         await connection.query(`ALTER TABLE ${entityName}
                             DROP FOREIGN KEY \`${foreignKeyResult.CONSTRAINT_NAME}\`;`);
                     } catch (err) {
-                        rollbackConnsAndExitProcess(
+                        await rollbackConnsAndExitProcess(
                             `Could not drop FK '${foreignKeyResult.CONSTRAINT_NAME}': ${err?.sqlMessage}`,
                             err,
                         );
@@ -683,40 +716,41 @@ const updateRelationships = async (dropOnly = false) => {
 
                     updatedRelationships.removed++;
                 } else {
-                    existingForeignKeys.push(foreignKeyResult.CONSTRAINT_NAME);
+                    existingForeignKeyDataArray.push(foreignKeyResult);
                 }
             }
         } catch (err) {
-            rollbackConnsAndExitProcess(
+            await rollbackConnsAndExitProcess(
                 `Could not get schema information for '${moduleName}': ${err?.sqlMessage}`,
                 err,
             );
         }
 
-        let existingForeignKeys = [];
-
         if (dropOnly) {
             continue;
         }
 
-        const foreignKeysToCreate = entityRelationshipConstraints.filter(
-            (x) => !existingForeignKeys.includes(x.constraintName),
+        const entityRelationshipConstraintsToCreate = entityRelationshipConstraints.filter(
+            (x) =>
+                !existingForeignKeyDataArray
+                    .map((existingForeignKeyData) => {
+                        return `${existingForeignKeyData.TABLE_NAME}_${existingForeignKeyData.REFERENCED_TABLE_NAME}_${existingForeignKeyData.COLUMN_NAME}`;
+                    })
+                    .includes(x.dataModelUniqueCombination),
         );
 
-        for (const foreignKeyToCreate of foreignKeysToCreate) {
-            const entityRelationship = getEntityRelationshipFromRelationshipColumn(
-                entityName,
-                foreignKeyToCreate.columnName,
-            );
-
+        for (const foreignKeyToCreate of entityRelationshipConstraintsToCreate) {
             try {
                 await connection.query(`ALTER TABLE ${entityName}
                 ADD CONSTRAINT \`${foreignKeyToCreate.constraintName}\` 
                 FOREIGN KEY (${foreignKeyToCreate.columnName})
-                REFERENCES ${entityRelationship} (${getPrimaryKeyColumn()})
+                REFERENCES ${foreignKeyToCreate.relatedEntityName} (${getPrimaryKeyColumn()})
                 ON DELETE SET NULL ON UPDATE CASCADE;`);
             } catch (err) {
-                rollbackConnsAndExitProcess(`Could not add FK '${foreignKeyToCreate}': ${err?.sqlMessage}`, err);
+                await rollbackConnsAndExitProcess(
+                    `Could not add FK ${foreignKeyToCreate.dataModelUniqueCombination} (${foreignKeyToCreate.constraintName})': ${err?.sqlMessage}`,
+                    err,
+                );
             }
 
             updatedRelationships.added++;
@@ -736,70 +770,21 @@ const updateRelationships = async (dropOnly = false) => {
 const getEntityRelationshipConstraint = (entityName) => {
     let entityRelationshipConstraint = [];
     const entityRelationships = dataModel[entityName]["relationships"];
-    for (const entityRelationship of Object.keys(entityRelationships)) {
-        for (const relationshipName of entityRelationships[entityRelationship]) {
-            const entityPart = entityName;
-            const relationshipPart = entityRelationship;
-            const relationshipNamePart = relationshipName;
-
-            let columnName = "";
-            let constraintName = "";
-            let splitter = "_";
-            switch (databaseCaseImplementation.toLowerCase()) {
-                case DB_IMPLEMENTATION_TYPES.SNAKE_CASE:
-                    splitter = "_";
-                    break;
-                case DB_IMPLEMENTATION_TYPES.PASCAL_CASE:
-                case DB_IMPLEMENTATION_TYPES.CAMEL_CASE:
-                    splitter = "";
-                    break;
-                default:
-                    splitter = "_";
-            }
-            columnName = relationshipPart + splitter + relationshipNamePart;
-
+    for (const relatedEntityName of Object.keys(entityRelationships)) {
+        for (const relationshipAttributeName of entityRelationships[relatedEntityName]) {
+            const dataModelUniqueCombination = `${entityName}_${relatedEntityName}_${relationshipAttributeName}`;
             const uniqueIdentifierRaw = Date.now().toString() + Math.round(1000000 * Math.random()).toString();
             const uniqueIdentifier = createHash("md5").update(uniqueIdentifierRaw).digest("hex");
-            entityRelationshipConstraint.push({ columnName, constraintName: uniqueIdentifier });
+            entityRelationshipConstraint.push({
+                relatedEntityName: relatedEntityName,
+                columnName: relationshipAttributeName,
+                dataModelUniqueCombination: dataModelUniqueCombination,
+                constraintName: uniqueIdentifier,
+            });
         }
     }
 
     return entityRelationshipConstraint;
-};
-
-/**
- * Determines the relationship, as defined in the data model from the given column name
- * @param entityName The name of the entity for which to determine the defined relationship
- * @param relationshipColumnName The column name in the database that represents the relationship
- * @return {string|null} The name of the relationship as defined in the data model
- */
-const getEntityRelationshipFromRelationshipColumn = (entityName, relationshipColumnName) => {
-    const entityRelationships = dataModel[entityName]["relationships"];
-    for (const entityRelationship of Object.keys(entityRelationships)) {
-        for (const relationshipName of entityRelationships[entityRelationship]) {
-            const relationshipPart = entityRelationship;
-            const relationshipNamePart = relationshipName;
-
-            let columnName = "";
-            switch (databaseCaseImplementation.toLowerCase()) {
-                case DB_IMPLEMENTATION_TYPES.SNAKE_CASE:
-                    columnName = relationshipPart + "_" + relationshipNamePart;
-                    break;
-                case DB_IMPLEMENTATION_TYPES.PASCAL_CASE:
-                case DB_IMPLEMENTATION_TYPES.CAMEL_CASE:
-                    columnName = relationshipPart + relationshipNamePart;
-                    break;
-                default:
-                    columnName = relationshipPart + "_" + relationshipNamePart;
-            }
-
-            if (columnName === relationshipColumnName) {
-                return entityRelationship;
-            }
-        }
-    }
-
-    return null;
 };
 
 /**
@@ -917,25 +902,9 @@ const getLockingConstraintColumn = () => {
 const getEntityRelationshipColumns = (entityName) => {
     let entityRelationshipColumns = [];
     const entityRelationships = dataModel[entityName]["relationships"];
-    for (const entityRelationship of Object.keys(entityRelationships)) {
-        for (const relationshipName of entityRelationships[entityRelationship]) {
-            const relationshipPart = entityRelationship;
-            const relationshipNamePart = relationshipName;
-
-            let columnName = "";
-            switch (databaseCaseImplementation.toLowerCase()) {
-                case DB_IMPLEMENTATION_TYPES.SNAKE_CASE:
-                    columnName = relationshipPart + "_" + relationshipNamePart;
-                    break;
-                case DB_IMPLEMENTATION_TYPES.PASCAL_CASE:
-                case DB_IMPLEMENTATION_TYPES.CAMEL_CASE:
-                    columnName = relationshipPart + relationshipNamePart;
-                    break;
-                default:
-                    columnName = relationshipPart + "_" + relationshipNamePart;
-            }
-
-            entityRelationshipColumns.push(columnName);
+    for (const relatedEntityName of Object.keys(entityRelationships)) {
+        for (const relationshipAttributeName of entityRelationships[relatedEntityName]) {
+            entityRelationshipColumns.push(relationshipAttributeName);
         }
     }
     return entityRelationshipColumns;

--- a/sync/optionValidation.js
+++ b/sync/optionValidation.js
@@ -1,4 +1,4 @@
-import { outputFormattedLog, printErrorMessage } from "dx-cli-tools/helpers.js";
+import { outputFormattedLog, printErrorMessage, printInfoMessage } from "dx-cli-tools/helpers.js";
 import { isValidObject, arePrimitiveArraysEqual } from "dx-utilities";
 import { DB_IMPLEMENTATION_TYPES, SUB_HEADING_FORMAT } from "../constants.js";
 import { getCaseNormalizedString } from "./sqlCaseHelpers.js";
@@ -186,6 +186,16 @@ const validateRelationship = (entityName, relationshipName, relationshipAttribut
 
     if (!Array.isArray(relationshipAttributes)) {
         printErrorMessage(`${entityName} (${relationshipName}) related attributes are not provided as an array`);
+        return false;
+    }
+
+    if (new Set(relationshipAttributes).size !== relationshipAttributes.length) {
+        printErrorMessage(`Error creating relationships for entity '${entityName}'.`);
+        printInfoMessage(
+            `Related attributes names can not duplicate.
+Provided: ${relationshipAttributes.join(", ")}`,
+            SUB_HEADING_FORMAT,
+        );
         return false;
     }
 

--- a/sync/optionValidation.js
+++ b/sync/optionValidation.js
@@ -92,19 +92,32 @@ export const validateDataModel = (
             return false;
         }
 
+        const allRelationshipAttributeNames = [];
         for (const [relationshipName, relationshipAttributes] of Object.entries(
             entityDefinitionToCheck.relationships,
         )) {
+            allRelationshipAttributeNames.push(...relationshipAttributes);
             const isValidRelationship = validateRelationship(
                 entityNameToCheck,
                 relationshipName,
                 relationshipAttributes,
             );
+
             if (!isValidRelationship) return false;
             entityDefinitionCased.relationships[getCaseNormalizedString(relationshipName, databaseCaseImplementation)] =
                 relationshipAttributes.map((attribute) =>
                     getCaseNormalizedString(attribute, databaseCaseImplementation),
                 );
+        }
+
+        if (new Set(allRelationshipAttributeNames).size !== allRelationshipAttributeNames.length) {
+            printErrorMessage(`Error creating relationships for entity '${entityNameToCheck}'.`);
+            printInfoMessage(
+                `Related attributes names can not duplicate.
+    Provided: ${allRelationshipAttributeNames.join(", ")}`,
+                SUB_HEADING_FORMAT,
+            );
+            return false;
         }
 
         if (!isValidObject(entityDefinitionToCheck.options)) {

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,33 @@
+# version: 1'
+# services:
+#     sql:
+#         container_name: divblox-tests-db
+#         image: mysql:8
+#         environment:
+#             MYSQL_ROOT_PASSWORD: "secret"
+#             MYSQL_USER: "dxuser"
+#             MYSQL_PASSWORD: "secret"
+#             # MYSQL_DATABASE: "dxdatabase"
+#         volumes:
+#             - "./init_scripts:/docker-entrypoint-initdb.d"
+#             - divblox-tests-sqldata:/var/lib/mysql
+#         ports:
+#             - 3369:3306
+
+# volumes:
+#     divblox-tests-sqldata: {}
+
+version: "1"
+services:
+    db:
+        image: mysql:8
+        command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+        volumes:
+            - ./scripts:/docker-entrypoint-initdb.d
+        ports:
+            - 3369:3306
+        environment:
+            MYSQL_ROOT_PASSWORD: secret
+volumes:
+    db:
+        driver: local

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,22 +1,3 @@
-# version: 1'
-# services:
-#     sql:
-#         container_name: divblox-tests-db
-#         image: mysql:8
-#         environment:
-#             MYSQL_ROOT_PASSWORD: "secret"
-#             MYSQL_USER: "dxuser"
-#             MYSQL_PASSWORD: "secret"
-#             # MYSQL_DATABASE: "dxdatabase"
-#         volumes:
-#             - "./init_scripts:/docker-entrypoint-initdb.d"
-#             - divblox-tests-sqldata:/var/lib/mysql
-#         ports:
-#             - 3369:3306
-
-# volumes:
-#     divblox-tests-sqldata: {}
-
 version: "1"
 services:
     db:

--- a/tests/scripts/001_schema_privileges_setup.sql
+++ b/tests/scripts/001_schema_privileges_setup.sql
@@ -1,0 +1,10 @@
+-- create databases
+CREATE DATABASE IF NOT EXISTS `dxdatabase`;
+CREATE DATABASE IF NOT EXISTS `dxdatabase_2`;
+
+-- create root user and grant rights
+CREATE USER 'dxuser'@'localhost' IDENTIFIED BY 'secret';
+
+-- GRANT ALL ON *.* TO 'dxuser'@'localhost';
+GRANT ALL ON `dxdatabase`.* TO 'dxuser'@'localhost';
+GRANT ALL ON `dxdatabase_2`.* TO 'dxuser'@'localhost';


### PR DESCRIPTION
## Added validation for duplicate relationships defined on:
- same relatedEntity
- in same entity regardless of relatedEntity

## Updated how relationship attributes are generated:
- old: current_table_name__provided_relationship_Name
- new: provided_relationship_name ONLY

The new way allows for the old naming to be used if required, but also frees up space if current_table_name is not desired.

## Checks for existing indexes (specifically FK constraint ones) was improved
syncDatabase() does not delete and re-add existing FK indexes. This should make the future sync tests more robust as we can assume indexes to remain through database syncs.

This was done by assuming `table_name + related_table_name + unique_column_name` parsed together uniquely identify the index in question. Allowing us to match it to an existing index and not have to delete it.

#### Updated rollbackConnsAndExitProcess() calls to await. Bug fix.

### Tests can now be done on 2 modules.
On docker container spin up:
-  2 databases being created
- dxuser given access to both

NOTE: have to recreate the container to execute startup SQL script